### PR TITLE
Fix Docker image build in CI for multi-arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,59 +2,26 @@
 
 ########## STAGE 1: build ##########
 FROM --platform=$BUILDPLATFORM rust:1-bookworm AS builder
-ARG TARGETPLATFORM
-ARG TARGETARCH
 
 WORKDIR /app
 
-# Elegir el target musl según la arquitectura
-RUN case "$TARGETARCH" in \
-      "amd64")  echo x86_64-unknown-linux-musl  > /rust_target ;; \
-      "arm64")  echo aarch64-unknown-linux-musl > /rust_target ;; \
-      *) echo "Arquitectura no soportada: $TARGETARCH" && exit 1 ;; \
-    esac \
- && rustup target add $(cat /rust_target)
-
-# Herramientas necesarias para compilar estático con musl y cross-compilation
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    musl-tools \
-    pkg-config \
-    ca-certificates \
-    gcc-aarch64-linux-gnu \
-    gcc-x86-64-linux-gnu \
- && update-ca-certificates \
- && rm -rf /var/lib/apt/lists/*
-
-# Configure cross-compilation linkers
-ENV CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
-ENV CC_x86_64_unknown_linux_musl=x86_64-linux-gnu-gcc  
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-gnu-gcc
-
-# --- Cacheo de dependencias de Cargo ---
-# Si usas workspace, copia también el Cargo.toml del workspace y los Cargo.toml de crates relevantes.
+# Cache dependencies
 COPY Cargo.toml Cargo.lock ./
-# Copia el src después para aprovechar capas de caché de dependencias
-COPY src ./src
+RUN cargo fetch
 
-# Compilar en release para el target elegido (with separate cache per target)
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=registry-$TARGETARCH \
-    --mount=type=cache,target=/app/target,id=target-$TARGETARCH \
-    RUST_TARGET=$(cat /rust_target) \
- && cargo build --release --target $RUST_TARGET \
- && install -Dm755 target/$RUST_TARGET/release/sftpgo-authelia-totp-hook /out/sftpgo-authelia-totp-hook
+# Build application
+COPY src ./src
+RUN cargo build --release
 
 ########## STAGE 2: runtime ##########
-FROM scratch AS runtime
+FROM debian:bookworm-slim AS runtime
 
-# (Opcional pero útil) Certificados raíz para TLS/HTTPS
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# Binario estático
-COPY --from=builder /out/sftpgo-authelia-totp-hook /sftpgo-authelia-totp-hook
+COPY --from=builder /app/target/release/sftpgo-authelia-totp-hook /usr/local/bin/sftpgo-authelia-totp-hook
 
-# Usuario no root (ID arbitrario). En scratch no hay /etc/passwd, pero esto funciona.
 USER 10001:10001
 
-ENTRYPOINT ["/sftpgo-authelia-totp-hook"]
+ENTRYPOINT ["sftpgo-authelia-totp-hook"]


### PR DESCRIPTION
## Summary
- simplify Dockerfile to rely on native builds
- enable QEMU in CI build job for multi-arch support

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f1a1191048331b00b45b8921171be